### PR TITLE
ci: follow semantic versioning and add missing `conf.json`

### DIFF
--- a/.github/docs/conf.json
+++ b/.github/docs/conf.json
@@ -1,0 +1,28 @@
+{
+  "source": {
+    "include": ["./src/", "./README.md"]
+  },
+  "opts": {
+    "template": "./node_modules/ink-docstrap/template",
+    "recurse": true
+  },
+  "templates": {
+    "cleverLinks": false,
+    "monospaceLinks": false,
+    "systemName": "@wfcd/profile-parser",
+    "footer": "",
+    "copyright": "©2024, WFCD",
+    "includeDate": true,
+    "navType": "vertical",
+    "theme": "cosmo",
+    "linenums": true,
+    "collapseSymbols": true,
+    "inverseNav": true,
+    "outputSourceFiles": true,
+    "outputSourcePath": true,
+    "dateFormat": "dddd, MMMM Do YYYY, HH:mm:ss",
+    "syntaxTheme": "dark",
+    "sort": "longname, version, since",
+    "search": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wfcd/profile-parser",
-  "version": "0.0-dev",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wfcd/profile-parser",
-      "version": "0.0-dev",
+      "version": "0.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wfcd/profile-parser",
-  "version": "0.0-dev",
+  "version": "0.0.0",
   "description": "Parser for Digital Extreme's profile data",
   "type": "module",
   "main": "src/ProfileParser.js",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixed the missing `0` in the version, removed the `-dev` part and add `conf.json` that I copied and pasted from arsenal-parser with an adjusted copyright date.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
