### PR TITLE
ci: run `npm install` before jsdoc and minor document changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+      - name: npm install
+        run: npm install
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         env:

--- a/src/Enemy.js
+++ b/src/Enemy.js
@@ -32,6 +32,7 @@ export default class Enemy {
 
     /**
      * The amount of kills that were assits
+     * @type {number}
      */
     this.assists = enemy.assists;
 

--- a/src/Intrinsics.js
+++ b/src/Intrinsics.js
@@ -1,6 +1,9 @@
 export default class Intrinsics {
   constructor(skills) {
     // I know this is railjack but I'm not sure what the context is
+    /**
+     * @type {number}
+     */
     this.space = skills.LPP_SPACE;
 
     /**

--- a/src/ItemConfig.js
+++ b/src/ItemConfig.js
@@ -26,25 +26,25 @@ export default class ItemConfig {
 
     /**
      * Primary colors applied to item if they exist
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (config.pricol) this.primaryColor = colors.mapColors(mapToHex(config.pricol));
 
     /**
      * Sigil colors applied to item if they exist
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (config.sigcol) this.sigilColor = colors.mapColors(mapToHex(config.sigcol));
 
     /**
      * Attachment colors applied to item if they exist
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (config.attcol) this.attachmentsColor = colors.mapColors(mapToHex(config.attcol));
 
     /**
      * Syandana colors applied to item if they exist
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (config.syancol) this.syandanaColor = colors.mapColors(mapToHex(config.syancol));
   }

--- a/src/LoadOutItem.js
+++ b/src/LoadOutItem.js
@@ -28,7 +28,7 @@ export default class LoadOutItem {
 
       /**
        * Complete item from Warframe-items
-       * @type {import('warframe-items').Item}
+       * @type {module:"warframe-items".Item}
        */
       this.item = item;
     }

--- a/src/OperatorLoadOuts.js
+++ b/src/OperatorLoadOuts.js
@@ -25,43 +25,43 @@ export default class OperatorLoadOuts {
 
     /**
      * Operator primary colors
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (loadout.pricol) this.primaryColor = colors.mapColors(mapToHex(loadout.pricol));
 
     /**
      * Operator sigil colors
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (loadout.sigcol) this.sigilColor = colors.mapColors(mapToHex(loadout.sigcol));
 
     /**
      * Operator attachment colors
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (loadout.attcol) this.attachmentsColor = colors.mapColors(mapToHex(loadout.attcol));
 
     /**
      * Operator syandana colors
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (loadout.syancol) this.syandanaColor = colors.mapColors(mapToHex(loadout.syancol));
 
     /**
      * Operator eye colors
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (loadout.eyecol) this.eyeColor = colors.mapColors(mapToHex(loadout.eyecol));
 
     /**
      * Operator facial colors
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (loadout.facial) this.facial = colors.mapColors(mapToHex(loadout.facial));
 
     /**
      * Operator cloth colors
-     * @type {import('warframe-items').ColorMap}
+     * @type {module:"warframe-items".ColorMap}
      */
     if (loadout.cloth) this.cloth = colors.mapColors(mapToHex(loadout.cloth));
   }

--- a/src/XpInfo.js
+++ b/src/XpInfo.js
@@ -16,7 +16,7 @@ export default class XpInfo {
 
     /**
      * The item corrosponding to the unique name.
-     * @type {import('warframe-items').Item | undefined}
+     * @type {module:"warframe-items".Item | undefined}
      */
     this.item = find.findItem(info.ItemType);
   }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Cleaned up jsdoc to use the module syntax instead and run `npm install` before running jsdoc

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Docs**
