### PR TITLE
ci: update `peaceiris/actions-gh-pages` to v4 and use `github_token` instead of `deploy_key`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build
         run: npm run build:docs
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          deploy_key: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
oh boy take 3

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Docs**
