### PR TITLE
feat: get weapon skin from `warframe-items` if possible

### DIFF
--- a/src/WeaponSkin.js
+++ b/src/WeaponSkin.js
@@ -1,3 +1,5 @@
+import { find } from 'warframe-items/utilities';
+
 /**
  * A weapon skin
  * @module
@@ -8,6 +10,9 @@ export default class WeaponSkin {
      * Unique name
      * @type {String}
      */
-    this.unuqueName = skin.ItemType;
+    this.uniqueName = skin.ItemType;
+
+    const item = find.findItem(skin.ItemType);
+    if (item) this.item = item;
   }
 }

--- a/test/unit/WeaponSkin.spec.js
+++ b/test/unit/WeaponSkin.spec.js
@@ -1,0 +1,49 @@
+import { assert } from 'chai';
+import { describe, it } from 'mocha';
+
+import WeaponSkin from '../../src/WeaponSkin.js';
+
+describe('WeaponSkins', () => {
+  describe('#constructor', () => {
+    it('handles some data', () => {
+      const data = [
+        {
+          ItemType: '/Lotus/Upgrades/Skins/Magician/LimboDeluxeHelmet',
+        },
+        {
+          ItemType: '/Lotus/Upgrades/Skins/Magician/LimboDeluxeSkin',
+        },
+        {
+          ItemType: '/Lotus/Upgrades/Skins/Effects/FootstepsEidolon',
+        },
+      ];
+
+      const skins = data.map((d) => new WeaponSkin(d));
+
+      for (let i = 0; i < skins.length; i += 1) {
+        assert.strictEqual(skins[i].item.uniqueName, data[i].ItemType);
+        assert.exists(skins[i].item.name);
+      }
+    });
+    it('return uniqueName with no item', () => {
+      const data = [
+        {
+          ItemType: '/Lotus/Upgrades/Skins/Magician/Limb',
+        },
+        {
+          ItemType: '/Lotus/Upgrades/Skins/Magician/Lim',
+        },
+        {
+          ItemType: '/Lotus/Upgrades/Skins/Effects/Foo',
+        },
+      ];
+
+      const skins = data.map((d) => new WeaponSkin(d));
+
+      for (let i = 0; i < skins.length; i += 1) {
+        assert.strictEqual(skins[i].uniqueName, data[i].ItemType);
+        assert.notExists(skins[i].item);
+      }
+    });
+  });
+});


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds the skins item data from `warframe-items` only if it exist

```javascript
{
	"uniqueName": name,
	"item": Item
}
```

I was gonna have the Item override the whole object but I realized those would by annoying for typed languages i.e.

```dart
// Before
class Skin {
	final String uniqueName;
  	final String? category;
    final String? description;
    final String? excludeFromCodex;
    final String? imageName;
    final String? masterable;
    final String? name;
    final String? tradable;
    final String? type;
}

// After
class Skin {
    final String uniqueName;
	final Item? item;
}

class Item {
	final String category;
    final String description;
    final String excludeFromCodex;
    final String imageName;
    final String masterable;
    final String name;
    final String tradable;
    final String type;
}
```

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**
