### PR TITLE
feat: expose mission uniqueName

### DIFF
--- a/src/Mission.js
+++ b/src/Mission.js
@@ -20,6 +20,12 @@ export default class Mission {
     this.node = node(uniqueName, locale);
 
     /**
+     * Node unique name
+     * @type {String}
+     */
+    this.nodeKey = uniqueName;
+
+    /**
      * Node mission type
      * @type {String}
      */

--- a/test/unit/mission.spec.js
+++ b/test/unit/mission.spec.js
@@ -15,6 +15,7 @@ describe('Mission', () => {
       const mission = new Mission(data, 'en');
 
       assert.strictEqual(mission.node, 'M Prime (Mercury)');
+      assert.strictEqual(mission.nodeKey, data.Tag);
       assert.strictEqual(mission.missionType, 'Extermination');
       assert.strictEqual(mission.faction, 'Crossfire');
     });
@@ -27,6 +28,7 @@ describe('Mission', () => {
       const mission = new Mission(data, 'en');
 
       assert.strictEqual(mission.node, 'Arcadia (Mars)');
+      assert.strictEqual(mission.nodeKey, data.type);
       assert.strictEqual(mission.missionType, 'Ancient Retribution');
       assert.strictEqual(mission.faction, 'Grineer');
       assert.strictEqual(mission.highScore, data.highScore);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
exposes the mission node's unique name along with its translated name

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**
