### PR TITLE
fix: drifter and railjack intrinsic points are reflected properly

### DIFF
--- a/src/Intrinsics.js
+++ b/src/Intrinsics.js
@@ -8,11 +8,11 @@ export default class Intrinsics {
    * @param {Object} skills The intrinsics object
    */
   constructor(skills) {
-    // I know this is railjack but I'm not sure what the context is
     /**
+     * Intrinsic points for railjack
      * @type {number}
      */
-    this.space = skills.LPP_SPACE;
+    this.railjack = Math.floor(skills.LPP_SPACE / 1000);
 
     /**
      * Railjack engineering rank
@@ -44,11 +44,11 @@ export default class Intrinsics {
      */
     this.command = skills.LPS_COMMAND;
 
-    // Not sure what the context for this one is either
     /**
+     * Intrinsic points for railjack
      * @type {number}
      */
-    this.drifter = skills.LPP_DRIFTER;
+    this.drifter = Math.floor(skills.LPP_DRIFTER / 1000);
 
     /**
      * Drifter riding rank

--- a/test/unit/intrinsics.spec.js
+++ b/test/unit/intrinsics.spec.js
@@ -19,7 +19,7 @@ describe('Intrinsics', () => {
 
       const intrinsics = new Intrinsics(playerSkills);
 
-      assert.strictEqual(intrinsics.space, playerSkills.LPP_SPACE);
+      assert.strictEqual(intrinsics.railjack, 125);
     });
   });
 });


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Figured out `LPP_SPACE` and LPP_DRIFTER` are the earned affinity that get turned into intrinsic points

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

https://warframe.fandom.com/wiki/Railjack/Intrinsics
> Each Intrinsic point requires 1000 [Affinity](https://warframe.fandom.com/wiki/Affinity) (1/10 of Affinity earned only goes into Instrinsic gain) which can be earned through a variety of activities during [Empyrean](https://warframe.fandom.com/wiki/Empyrean) missions, and unlike regular missions [Affinity Range](https://warframe.fandom.com/wiki/Affinity#Affinity_Range) is infinite so all [Squad](https://warframe.fandom.com/wiki/Squad) members benefit regardless of their locations

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
