### PR TITLE
fix: profile alliance id can be null

### DIFF
--- a/src/Profile.js
+++ b/src/Profile.js
@@ -94,7 +94,7 @@ export default class Profile {
      * Alliance ID
      * @type {String}
      */
-    this.allianceId = profile.AllianceId.$oid;
+    if (profile.AllianceId.$oid) this.allianceId = profile.AllianceId.$oid;
 
     /**
      * Assassins currently asfter the player


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
fixes an issue posted by sentry under https://github.com/WFCD/warframe-status/pull/1652

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
