### PR TITLE
fix: Fix various undefined errors on older profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm i -S @wfcd/profile-parser
 import { ProfileParser } from 'profile-parser';
 
 const profileData = await fetch('https://content.warframe.com/dynamic/getProfileViewingData.php?n=${username}');
-const user = new ProfileParser(await profileData.text());
+const user = new ProfileParser(await profileData.json());
 
 console.log(user.profile.displayName);
 ```

--- a/src/Intrinsics.js
+++ b/src/Intrinsics.js
@@ -12,66 +12,66 @@ export default class Intrinsics {
      * Intrinsic points for railjack
      * @type {number}
      */
-    this.railjack = Math.floor(skills.LPP_SPACE / 1000);
+    this.railjack = Math.floor((skills.LPP_SPACE ?? 0) / 1000);
 
     /**
      * Railjack engineering rank
      * @type {number}
      */
-    this.engineering = skills.LPS_ENGINEERING;
+    this.engineering = skills.LPS_ENGINEERING ?? 0;
 
     /**
      * Railjack gunnery rank
      * @type {number}
      */
-    this.gunnery = skills.LPS_GUNNERY;
+    this.gunnery = skills.LPS_GUNNERY ?? 0;
 
     /**
      * Railjack piloting rank
      * @type {number}
      */
-    this.piloting = skills.LPS_PILOTING;
+    this.piloting = skills.LPS_PILOTING ?? 0;
 
     /**
      * Railjack tactical rank
      * @type {number}
      */
-    this.tactical = skills.LPS_TACTICAL;
+    this.tactical = skills.LPS_TACTICAL ?? 0;
 
     /**
      * Railjack command rank
      * @type {number}
      */
-    this.command = skills.LPS_COMMAND;
+    this.command = skills.LPS_COMMAND ?? 0;
 
     /**
      * Intrinsic points for railjack
      * @type {number}
      */
-    this.drifter = Math.floor(skills.LPP_DRIFTER / 1000);
+    this.drifter = Math.floor((skills.LPP_DRIFTER ?? 0) / 1000);
 
     /**
      * Drifter riding rank
      * @type {number}
      */
-    this.riding = skills.LPS_DRIFT_RIDING;
+    this.riding = skills.LPS_DRIFT_RIDING ?? 0;
 
     /**
      * Drifter combat rank
      * @type {number}
      */
-    this.combat = skills.LPS_DRIFT_COMBAT;
+    this.combat = skills.LPS_DRIFT_COMBAT ?? 0;
 
     /**
      * Drifter opportunity rank
      * @type {number}
      */
-    this.opportunity = skills.LPS_DRIFT_OPPORTUNITY;
+    this.opportunity = skills.LPS_DRIFT_OPPORTUNITY ?? 0;
 
     /**
      * Drifter endurance rank
      * @type {number}
      */
-    this.endurance = skills.LPS_DRIFT_ENDURANCE;
+    this.endurance = skills.LPS_DRIFT_ENDURANCE ?? 0;
   }
 }

--- a/src/Profile.js
+++ b/src/Profile.js
@@ -60,7 +60,7 @@ export default class Profile {
      * Railjack and drifter Intrinsics
      * @type {Intrinsics}
      */
-    this.intrinsics = new Intrinsics(profile.PlayerSkills);
+    this.intrinsics = new Intrinsics(profile.PlayerSkills ?? {});
 
     /**
      * Nightwave challenges progress
@@ -72,7 +72,7 @@ export default class Profile {
      * Guild ID
      * @type {String}
      */
-    this.guildId = profile.GuildId.$oid;
+    if (profile.GuildId?.$oid) this.guildId = profile.GuildId.$oid;
 
     /**
      * Guild name
@@ -150,7 +150,7 @@ export default class Profile {
      * Player standing and title across all syndicates
      * @type {Array<Syndicate>}
      */
-    this.syndicates = profile.Affiliations.map((a) => new Syndicate(a));
+    this.syndicates = profile.Affiliations?.map((a) => new Syndicate(a)) ?? [];
 
     /**
      * Daily standing per Syndicate
@@ -206,8 +206,8 @@ export default class Profile {
 
     /**
      * Player's alignment
-     * @type {Map<String,number>}
+     * @type {Map<String,number | undefined>}
      */
-    this.alignment = { wisdom: profile.Alignment.Wisdom, alignment: profile.Alignment.Alignment };
+    this.alignment = { wisdom: profile.Alignment?.Wisdom, alignment: profile.Alignment?.Alignment };
   }
 }

--- a/src/Profile.js
+++ b/src/Profile.js
@@ -21,8 +21,8 @@ export default class Profile {
    */
   constructor(profile, locale = 'en', withItem = false) {
     /**
-     * Player's acount ID
-     * @type {Stirng}
+     * Player's account ID
+     * @type {String}
      */
     this.accountId = profile.AccountId.$oid;
 
@@ -45,7 +45,7 @@ export default class Profile {
     this.masteryRank = profile.PlayerLevel;
 
     /**
-     * Load out preset equiped
+     * Load out preset equipped
      * @type {LoadOutPreset | undefined}
      */
     if (profile.LoadOutPreset) this.preset = new LoadOutPreset(profile.LoadOutPreset);
@@ -118,13 +118,13 @@ export default class Profile {
 
     /**
      * Whether or not the player is qualified as a target for Zanuka
-     * @type {bool}
+     * @type {boolean}
      */
     this.harvestable = profile.Harvestable;
 
     /**
      * Whether or not the player is qualified as a target for a syndicate death squad
-     * @type {bool}
+     * @type {boolean}
      */
     this.deathSquadable = profile.DeathSquadable;
 
@@ -136,7 +136,7 @@ export default class Profile {
 
     /**
      * Whether the user has migrated to console or not
-     * @type {bool}
+     * @type {boolean}
      */
     this.migratedToConsole = profile.MigratedToConsole;
 
@@ -187,14 +187,14 @@ export default class Profile {
     this.wishList = profile.Wishlist;
 
     /**
-     * Whhether the player has unlocked thier operator or not
-     * @type {bool}
+     * Whether the player has unlocked their operator or not
+     * @type {boolean}
      */
     this.unlockedOperator = profile.UnlockedOperator;
 
     /**
-     * Whether the player has unlocked their alignement or not
-     * @type {bool}
+     * Whether the player has unlocked their alignment or not
+     * @type {boolean}
      */
     this.unlockedAlignment = profile.UnlockedAlignment;
 

--- a/src/Stats.js
+++ b/src/Stats.js
@@ -194,7 +194,7 @@ export default class Stats {
      * List of scanned Warframe objects
      * @type {Array<Scan>}
      */
-    this.scans = stats.Scans.map((s) => new Scan(s));
+    this.scans = stats.Scans?.map((s) => new Scan(s)) ?? [];
 
     /**
      * Team revives

--- a/src/Stats.js
+++ b/src/Stats.js
@@ -23,7 +23,7 @@ export default class Stats {
     this.guildName = stats.GuildName;
 
     /**
-     * Player's total accumalted xp
+     * Player's total accumulated xp
      * @type {String}
      */
     this.xp = stats.XP;
@@ -35,25 +35,25 @@ export default class Stats {
     this.missionsCompleted = stats.MissionsCompleted;
 
     /**
-     * MIssions quit
+     * Missions quit
      * @type {number}
      */
     this.missionsQuit = stats.MissionsQuit;
 
     /**
-     * MIsions failed
+     * Misions failed
      * @type {number}
      */
     this.missionsFailed = stats.missionsFailed;
 
     /**
-     * MIssions interrupted
+     * Missions interrupted
      * @type {number}
      */
     this.missionsInterrupted = stats.MissionsInterrupted;
 
     /**
-     * MIssions dumped
+     * Missions dumped
      * @type {number}
      */
     this.missionsDumped = stats.MissionsDumped;
@@ -95,7 +95,7 @@ export default class Stats {
     this.forestEventScoreSum = stats.ForestEventScoreSum;
 
     /**
-     * Melee kilss
+     * Melee kills
      * @type {number}
      */
     this.meleeKills = stats.MeleeKills;
@@ -107,7 +107,7 @@ export default class Stats {
     this.abilities = stats.Abilities.map((a) => new Ability(a));
 
     /**
-     * Ciphers completed succefully
+     * Ciphers completed successfully
      * @type {number}
      */
     this.ciphersSolved = stats.CiphersSolved;


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- Fix various undefined errors on older profiles:
  - PlayerSkills
  - GuildId
  - Affiliations
  - Alignment
  - Scans
- Fix typos in documentation
- Fix README.md example usage

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->
Run profile parser through the user `PrisonKid`

---

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Docs]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README.md example to use `json()` method for profile data parsing
	- Fixed typos and improved comments in `Stats.js`

- **Bug Fixes**
	- Enhanced robustness in `Intrinsics.js` by adding nullish coalescing for skill properties
	- Improved error handling in `Profile.js` with safer property access and default values

- **Code Quality**
	- Corrected type annotations in `Profile.js`
	- Added optional chaining and nullish coalescing in various files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->