### PR TITLE
ci: update gh action prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,4 @@ updates:
     schedule:
       interval: 'daily'
     commit-message:
-      prefix: 'fix'
-      prefix-development: 'ci'
+      prefix: 'ci'


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
update the actions dependency update prefix to match what it does

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**
